### PR TITLE
Cross-reference BASE-256 from BinTEL and TEL specs

### DIFF
--- a/bintel-spec.md
+++ b/bintel-spec.md
@@ -10,6 +10,12 @@ encoding.
 BinTEL provides an unambiguous, compact serialization of the semantic model, suitable for hashing,
 transmission, and schema identification.
 
+A BinTEL document is defined here as a byte sequence. Where a text-oriented carrier is required —
+embedding in a TEL document, transmission over a textual channel, display, or copy-and-paste — a
+BinTEL byte sequence MAY be encoded as Unicode text using BASE-256 (see
+[BASE-256 Specification](base256-spec.md)). The textual form is character-for-byte with the byte
+sequence and is recovered losslessly by the BASE-256 decoder. See §9 for the conformance details.
+
 ## 1. Status
 
 This document is a draft specification of BinTEL.
@@ -68,7 +74,9 @@ its keyword index and its parent's type, BinTEL encodes no type tags.
 
 A BinTEL file consists of the following fields in order:
 
-1. **Magic number**: the 2 bytes `C0 D1`
+1. **Magic number**: the 2 bytes `C0 D1`. When the document is carried in BASE-256 textual form
+   (§9), these bytes appear as the two characters at positions `0xC0` and `0xD1` of the BASE-256
+   alphabet defined in the [BASE-256 Specification](base256-spec.md).
 2. **Schema signature**: the byte length of the signature (integer), followed by the signature
    bytes. The schema signature identifies the composed schema (base plus layers) used to type the
    document. Its construction is defined in §8.
@@ -150,3 +158,25 @@ decoding the document root.
 
 Schema compatibility is defined in §8.2 of the TEL Specification in terms of subsequence
 relationships between decoded signature hash sequences.
+
+## 9. Textual Encoding
+
+A BinTEL byte sequence MAY be represented as Unicode text by applying the BASE-256 encoding defined
+in the [BASE-256 Specification](base256-spec.md). The textual form has one Unicode character per
+input byte; the original bytes are recovered by the BASE-256 decoder, which computes the input
+byte as the Unicode code point of each character taken modulo 256.
+
+The choice of textual or byte form is purely a transport concern. No structural rule defined
+elsewhere in this specification is altered by the choice:
+
+- The value hash (§3) is computed over the BinTEL document root **as bytes**, not over its
+  BASE-256 textual form.
+- The schema signature (§8) is constructed and decoded over **bytes**, not over their BASE-256
+  textual form.
+- The magic number (§6), schema signature length, and all integer and node encodings (§4, §7) are
+  defined in terms of bytes and remain unchanged.
+
+A producer that emits BinTEL in textual form MUST apply BASE-256 to the complete byte sequence
+defined by §6, including the magic number and schema signature. A consumer that receives BinTEL in
+textual form MUST first decode the BASE-256 input back to bytes before applying any rule of this
+specification.

--- a/spec.md
+++ b/spec.md
@@ -1393,6 +1393,11 @@ The binary encoding of the semantic model, BinTEL, is defined in the companion
 documents and defines the schema signature and value hash constructions used for schema
 identification (§8.1) and compatibility checking (§8.2).
 
+When a BinTEL document is to be carried in a text-oriented context, it MAY be encoded as Unicode
+text using [BASE-256](base256-spec.md), defined as a companion specification. The BASE-256 textual
+form is character-for-byte with the BinTEL byte sequence and is recovered losslessly by the
+BASE-256 decoder.
+
 ## 21. Validation
 
 Type assignment (§20.2) ascribes a `Type` to every node. For `Struct` and `Flag` types, the


### PR DESCRIPTION
## Summary

Follow-up to #12 (now merged). Adds four pointers from the BinTEL and TEL specs to the freshly merged BASE-256 specification so that an implementor reading either spec is told where the textual carrier of BinTEL bytes is defined.

- `bintel-spec.md` abstract: short paragraph stating BinTEL is defined as a byte sequence and that BASE-256 is the canonical textual carriage.
- `bintel-spec.md` §6 (File Layout): annotates the magic-number bullet (`C0 D1`) with the BASE-256 alphabet positions where those bytes appear.
- `bintel-spec.md` new §9 (Textual Encoding): one short normative section stating that the value hash (§3), schema signature (§8), and structural rules (§4, §6, §7) are all defined over bytes, not over the BASE-256 textual form — i.e. textual encoding is a pure transport choice that does not alter any other rule.
- `spec.md` §20.4 (BinTEL): one short paragraph appended pointing to BASE-256 as an alternative carrier.

## Out of scope

- The magic-number contradiction (`bintel-spec.md` says `C0 D1`, `readme.md` says `b1 c0 d1`) is **not** resolved here. This PR documents §6 as it stands.
- The `printable UTF-8` claim in `readme.md` is not edited.
- `palimpsest/intro.md` has unrelated in-progress modifications in the working tree which were deliberately excluded from this commit.

## Test plan

- [ ] Render `bintel-spec.md` and `spec.md` and confirm the `[BASE-256 Specification](base256-spec.md)` / `[BASE-256](base256-spec.md)` links resolve against the merged `base256-spec.md` on `main`.
- [ ] Sanity-check that §9's invariants (hash/signature/magic-number are over bytes) match the existing wording in §3 and §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)