### PR TITLE
Fix literal-atom indentation in readme and spec examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,9 +69,11 @@ contact alice
 
 ### Hosting other languages
 
-A *source atom* is an indented block whose payload is captured verbatim. A *literal atom*
-uses an arbitrary delimiter line and preserves every byte of its payload — including
-trailing spaces, leading whitespace, and the sigil character.
+A *source atom* is an indented block whose payload is captured verbatim, with the block's
+own indentation stripped. A *literal atom* uses an arbitrary delimiter line and preserves
+every byte of its payload — including trailing spaces, leading whitespace, and the sigil
+character. Because nothing is stripped, the payload and the closing delimiter both begin at
+column zero; only the opening delimiter line is indented.
 
 ```tel
 fixture sample-payload
@@ -83,9 +85,9 @@ fixture sample-payload
 
   shell
         ---
-        #!/usr/bin/env bash
-        echo "Greetings from $(hostname)"
-        ---
+#!/usr/bin/env bash
+echo "Greetings from $(hostname)"
+---
 ```
 
 ### Schemas

--- a/spec/tel.md
+++ b/spec/tel.md
@@ -696,13 +696,14 @@ the opening indent. The scan uses bare `LF` regardless of the document's line-en
 payload is everything between the opening `LF` (exclusive) and the closing `LF` before the
 delimiter (exclusive). The `LF` after the closing delimiter terminates the literal atom.
 
-For example, a literal atom nested two indent levels deep with delimiter `END` looks like this
-(note that the closing `END` is flush left, not indented):
+For example, a literal atom with delimiter `END`, opened three indent levels below its compound
+line `inner`, looks like this (note that the closing `END` is flush left, not indented, and that
+the payload's leading spaces are preserved because no indentation is stripped):
 
 ```text
 outer
   inner
-      END
+        END
         leading-space-preserved-content
 END
   sibling-of-inner


### PR DESCRIPTION
A literal atom strips no indentation: its payload is preserved byte for byte and its closing delimiter must match flush-left at column zero (§15). Both worked examples violated this.

- readme.md: the `shell` example indented the payload and the closing `---` by 8 spaces. As written it is unterminated (E115) and would carry 8 leading spaces into every payload line. Flush-left the payload and closing delimiter; add a sentence noting only the opening delimiter is indented.
- spec/tel.md §15: the example opened `END` at +2 indent levels, which the parser reads as a source atom, not a literal. Move it to +3 levels (the documented threshold) and state the depth precisely.

Verified against the reference parser: the corrected snippets parse with no errors and yield clean, unindented payloads.